### PR TITLE
Fix OIDC docs

### DIFF
--- a/content/en/docs/configuration/Authentication/oidc.md
+++ b/content/en/docs/configuration/Authentication/oidc.md
@@ -44,17 +44,19 @@ auth:
 
 ## Issuer URL Examples
 
-**Authentik/Authelia**:
+**Authentik**:
 ```
 https://domain.com/application/o/filebrowser/
 ```
 
-**Pocket ID**:
+**Pocket ID/Authelia**:
 ```
-https://domain.com/
+https://domain.com
 ```
 
 ## Callback URL
+
+Append `/api/auth/oidc/callback` to the end of your base URL to get FileBrowser's OIDC callback URL.
 
 Configure in your OIDC provider:
 
@@ -62,7 +64,7 @@ Configure in your OIDC provider:
 https://your-domain.com/api/auth/oidc/callback
 ```
 
-With custom baseURL:
+If you a custom baseURL in your `config.yaml`:
 ```
 https://your-domain.com/custom-base/api/auth/oidc/callback
 ```


### PR DESCRIPTION
**Description**

All changes are considered, but for now please only add english documentation.

- [x] Documentation is english only (a requirement for now).
- [x] Your documentation is accurate to the latest version of FileBrowser Quantum.
- [x] If your styles are complex, you should test how they look and post a screenshot.
- [x] Must pass build check.

**Additional Details**

For now, please update documentation in `content/en/docs` until a translation process is fully available.

---

There were some correction in OIDC docs. Noticed those when changing from Password auth > Authelia. Plus, I made callback URL section a bit verbose.